### PR TITLE
use nixpkgs-python for python overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -34,10 +50,35 @@
         "type": "github"
       }
     },
+    "nixpkgs-python": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710929962,
+        "narHash": "sha256-CuPuUyX1TmxJDDZFOZMr7kHTzA8zoSJaVw0+jDVo2fw=",
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "rev": "a9e19aafbf75b8c7e5adf2d7319939309ebe0d77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "nixpkgs-python",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-python": "nixpkgs-python"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,15 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     flake-utils.url = "github:numtide/flake-utils";
+
+    nixpkgs-python = {
+      url = "github:cachix/nixpkgs-python";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
 
-  outputs = {
+  outputs = inputs @ {
     nixpkgs,
     flake-utils,
     ...
@@ -13,6 +19,7 @@
     {
       overlays = {
         nodejs = import ./nodejs/overlay.nix;
+        python = import ./python/overlay.nix inputs.nixpkgs-python;
       };
     }
     // flake-utils.lib.eachDefaultSystem (system: let
@@ -35,5 +42,6 @@
       '';
 
       packages.nodejsVersions = pkgs.callPackage ./nodejs {};
+      packages.pythonVersions = pkgs.callPackage ./python {inherit (inputs) nixpkgs-python;};
     });
 }

--- a/python/default.nix
+++ b/python/default.nix
@@ -1,0 +1,19 @@
+{
+  lib,
+  nixpkgs-python,
+  system,
+}: let
+  python-pkgs = nixpkgs-python.packages.${system};
+
+  isPythonVersion = version: let
+    semver-parts = lib.splitString "." version;
+
+    is-v3-release = (lib.elemAt semver-parts 0) == "3";
+    is-three-version-parts = builtins.length semver-parts == 3;
+    is-3-0-0 = semver-parts == ["3" "0"];
+  in
+    is-3-0-0 || is-v3-release && is-three-version-parts;
+
+  versions = lib.filterAttrs (version: _: isPythonVersion version) python-pkgs;
+in
+  versions

--- a/python/overlay.nix
+++ b/python/overlay.nix
@@ -1,0 +1,3 @@
+nixpkgs-python: final: prev: {
+  pythonVersions = final.callPackage ./. {inherit nixpkgs-python;};
+}


### PR DESCRIPTION
Why
===

we want to provide python packages, and nixpkgs-python is *pretty close* to the desired design of overlang

NOTE: i didn't do the latest alias stuff. i'm still not convinced about doing these as attributes...

What changed
============

added python overlay as a subset of the `nixpkgs-python` overlay

Test plan
=========

`nix build '.#pythonVersions."<some 3.x.x version>"'` works