### PR TITLE
ruby: init overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,7 +1,6 @@
 {
   "nodes": {
     "flake-compat": {
-      "flake": false,
       "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
@@ -52,7 +51,9 @@
     },
     "nixpkgs-python": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": [
+          "flake-compat"
+        ],
         "flake-utils": [
           "flake-utils"
         ],
@@ -74,11 +75,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-ruby": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1712986883,
+        "narHash": "sha256-uLXukCAjJ0Ews9eMMxH00JcxYWeA/fsjaHn47s/ilgU=",
+        "owner": "bobvanderlinden",
+        "repo": "nixpkgs-ruby",
+        "rev": "605170bed96a011b5264c9c3d124be79b016ce93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bobvanderlinden",
+        "repo": "nixpkgs-ruby",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "nixpkgs-python": "nixpkgs-python",
+        "nixpkgs-ruby": "nixpkgs-ruby",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,26 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
+    flake-compat.url = "github:edolstra/flake-compat";
     flake-utils.url = "github:numtide/flake-utils";
 
     nixpkgs-python = {
       url = "github:cachix/nixpkgs-python";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-compat.follows = "flake-compat";
       inputs.flake-utils.follows = "flake-utils";
     };
 
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
+
+    nixpkgs-ruby = {
+      url = "github:bobvanderlinden/nixpkgs-ruby";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-compat.follows = "flake-compat";
       inputs.flake-utils.follows = "flake-utils";
     };
   };
@@ -27,6 +36,7 @@
         nodejs = import ./nodejs/overlay.nix;
         python = import ./python/overlay.nix inputs.nixpkgs-python;
         rust = import ./rust/overlay.nix inputs.rust-overlay;
+        ruby = import ./ruby/overlay.nix inputs.nixpkgs-ruby;
       };
     }
     // flake-utils.lib.eachDefaultSystem (system: let
@@ -52,5 +62,6 @@
       packages.nodejsVersions = pkgs.callPackage ./nodejs {};
       packages.pythonVersions = pkgs.callPackage ./python {inherit (inputs) nixpkgs-python;};
       packages.rustVersions = pkgs.callPackage ./rust {inherit (inputs) rust-overlay;};
+      packages.rubyVersions = pkgs.callPackage ./ruby {inherit (inputs) nixpkgs-ruby;};
     });
 }

--- a/ruby/default.nix
+++ b/ruby/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  nixpkgs-ruby,
+  system,
+}: let
+  isRubyVersion = version: let
+    version-part = builtins.elemAt (lib.splitString "-" version);
+
+    is-ruby = version-part 0 == "ruby";
+
+    is-star-alias = lib.hasSuffix "*" version;
+    is-other-alias = lib.pipe (version-part 1) [
+      (lib.splitString ".")
+      builtins.length
+      (len: len != 3)
+    ];
+    is-alias = is-star-alias || is-other-alias;
+
+    is-not-supported = lib.hasPrefix "1." (version-part 1);
+  in
+    is-ruby && !is-alias && !is-not-supported;
+
+  versions = lib.pipe nixpkgs-ruby.packages.${system} [
+    (lib.filterAttrs (version: _: isRubyVersion version))
+    lib.attrsToList
+    (builtins.map ({
+      name,
+      value,
+    }: {
+      inherit value;
+      name = lib.removePrefix "ruby-" name;
+    }))
+    builtins.listToAttrs
+  ];
+in
+  versions

--- a/ruby/overlay.nix
+++ b/ruby/overlay.nix
@@ -1,0 +1,3 @@
+nixpkgs-ruby: final: prev: {
+  rubyVersions = final.callPackage ./. {inherit nixpkgs-ruby;};
+}


### PR DESCRIPTION
Why
===

moar coverage

What changed
============

- added `nixpkgs-ruby` as a flake input
- added `rubyVersions` package output with ruby versions list
- added `ruby` overlay

Test plan
=========

`nix build 'github:replit/overlang/cad/init-ruby#rubyVersions."3.3.0"'`
lower than 3.1.0 you'll get nix error about openssl 1.1 being insecure