### PR TITLE
rust: init overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -78,7 +78,31 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-python": "nixpkgs-python"
+        "nixpkgs-python": "nixpkgs-python",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1713233539,
+        "narHash": "sha256-dPGrCy5ttx6E3bUOmDynY/cAotRqvoIAimZlbv+Zr1w=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "847bc25ebab8dc72a86d2b1f0c088740eebbb1b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,12 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.flake-utils.follows = "flake-utils";
+    };
   };
 
   outputs = inputs @ {
@@ -20,6 +26,7 @@
       overlays = {
         nodejs = import ./nodejs/overlay.nix;
         python = import ./python/overlay.nix inputs.nixpkgs-python;
+        rust = import ./rust/overlay.nix inputs.rust-overlay;
       };
     }
     // flake-utils.lib.eachDefaultSystem (system: let
@@ -44,5 +51,6 @@
 
       packages.nodejsVersions = pkgs.callPackage ./nodejs {};
       packages.pythonVersions = pkgs.callPackage ./python {inherit (inputs) nixpkgs-python;};
+      packages.rustVersions = pkgs.callPackage ./rust {inherit (inputs) rust-overlay;};
     });
 }

--- a/rust/default.nix
+++ b/rust/default.nix
@@ -1,0 +1,54 @@
+{
+  extend,
+  lib,
+  rust-overlay,
+  symlinkJoin,
+  system,
+}: let
+  pkgs = extend rust-overlay.overlays.default;
+
+  mkDistribution = toolchain:
+    toolchain.default.overrideAttrs (prev: {
+      passthru =
+        prev.passthru
+        // {
+          components = let
+            component-names = [
+              "cargo"
+              "clippy"
+              "clippy-preview"
+              "llvm-tools"
+              "llvm-tools-preview"
+              "rls"
+              "rls-preview"
+              "rust"
+              "rust-analysis"
+              "rust-analyzer"
+              "rust-analyzer-preview"
+              "rust-docs"
+              "rust-src"
+              "rust-std"
+              "rustc"
+              "rustc-dev"
+              "rustfmt"
+              "rustfmt-preview"
+            ];
+          in
+            lib.getAttrs component-names toolchain;
+
+          profiles = lib.getAttrs ["complete" "default" "minimal"] toolchain;
+
+          withComponents = components:
+            symlinkJoin {
+              name = "rust-toolchain-with-components";
+              paths = lib.getAttrs components toolchain;
+            };
+        };
+    });
+
+  stable = lib.mapAttrs (version: mkDistribution) (lib.attrsets.removeAttrs pkgs.rust-bin.stable ["latest"]);
+  beta = lib.mapAttrs (version: mkDistribution) (lib.attrsets.removeAttrs pkgs.rust-bin.beta ["latest"]);
+  nightly = lib.mapAttrs (version: mkDistribution) (lib.attrsets.removeAttrs pkgs.rust-bin.nightly ["latest"]);
+in {
+  inherit stable beta nightly;
+}

--- a/rust/overlay.nix
+++ b/rust/overlay.nix
@@ -1,0 +1,5 @@
+rust-overlay: final: prev: {
+  rustVersions = final.callPackage ./default.nix {
+    inherit rust-overlay;
+  };
+}


### PR DESCRIPTION
Why
===

gotta represent the mushroom language

note that this overlay brings a slightly different design from the other overlays, given rust's unique distribution strategy. key points:
- instead of `rustVersions` being a flat attrset of derivations containing exact versions of the rust toolchain, it's an attrset with 3 attrs representing each distribution channel for rust: `stable`, `beta`, and `nightly`
- each derivation representing the distribution of a version (eg `pkgs.rustVersions.stable."1.77.2"`) only represents that version's default profile. for example, rust 1.77.2 will contain rust-analyzer, but 1.24.0 won't.
- additionally, the distribution derivations from the above point have additional passthru attrs allowing finer granularity to components. i envision this as compatible with both `.replit` and `rust-toolchain.toml`, but the exact machinery isn't as straightforward
- note that several nightly versions will fail to evaluate/build. i'll need to provide a function similar to [rust-overlay's `selectLatestNightlyWith`](https://github.com/oxalica/rust-overlay/blob/master/README.md#cheat-sheet-common-usage-of-rust-bin) in order to provide better ux with accessing nightly distributions of rust via overlang

What changed
============

initialized the rust overlay

Test plan
=========

```
nix build 'github:replit/overlang/cad/init-rust#rustVersions.stable."1.77.2"'
nix build 'github:replit/overlang/cad/init-rust#rustVersions.stable."1.77.2".components.rustc'
nix build 'github:replit/overlang/cad/init-rust#rustVersions.beta."2024-04-13"'
```